### PR TITLE
feat: Add prettier step to workflow before linting for better release preparation

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: ${{ github.ref }}
         uses: actions/checkout@v4
 
       - name: Prettify code

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -12,6 +12,20 @@ on:
 permissions: {}
 
 jobs:
+  prettier:
+    if: github.ref == 'release-please--branches--master'
+    name: Prettify code base # Mainly the automaic change log file created by release-please, which is on the release-please branch.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prettify code
+        uses: creyD/prettier_action@v4
+        with:
+          prettier_options: --write
   lint:
+    needs: prettier
     name: Lint code base
     uses: andrew-field/reusable-workflows/.github/workflows/super-linter.yml@master

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,5 +28,5 @@ jobs:
   lint:
     if: ${{ always() }} # This job will always run after the prettier job, regardless of the outcome. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs
     needs: prettier
-    name: ${{ github.ref }}
+    name: ${{ github.head_ref }}
     uses: andrew-field/reusable-workflows/.github/workflows/super-linter.yml@master

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prettify code
-        uses: creyD/prettier_action@v4
+        uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write
   lint:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           prettier_options: --write
   lint:
+    if: ${{ always() }} # This job will always run after the prettier job, regardless of the outcome. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs
     needs: prettier
     name: Lint code base
     uses: andrew-field/reusable-workflows/.github/workflows/super-linter.yml@master

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   prettier:
-    if: github.ref == 'release-please--branches--master'
+    if: github.head_ref != 'release-please--branches--master'
     name: Prettify code base # Mainly the automaic change log file created by release-please, which is on the release-please branch.
     runs-on: ubuntu-latest
 
@@ -28,5 +28,5 @@ jobs:
   lint:
     if: ${{ always() }} # This job will always run after the prettier job, regardless of the outcome. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs
     needs: prettier
-    name: ${{ github.head_ref }}
+    name: Lint code base
     uses: andrew-field/reusable-workflows/.github/workflows/super-linter.yml@master

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,8 +13,8 @@ permissions: {}
 
 jobs:
   prettier:
-    if: github.head_ref != 'release-please--branches--master'
-    name: Prettify code base # Mainly the automaic change log file created by release-please, which is on the release-please branch.
+    if: github.head_ref == 'release-please--branches--master'
+    name: Prettify code base # Mainly lint the automaic change log file created by release-please, which is on the release-please branch.
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write
+          prettier_options: --write **/*.{md} # Prettify all markdown files
   lint:
     if: ${{ always() }} # This job will always run after the prettier job, regardless of the outcome. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs
     needs: prettier

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: ${{ github.ref }}
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Prettify code
@@ -28,5 +28,5 @@ jobs:
   lint:
     if: ${{ always() }} # This job will always run after the prettier job, regardless of the outcome. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs
     needs: prettier
-    name: Lint code base
+    name: ${{ github.ref }}
     uses: andrew-field/reusable-workflows/.github/workflows/super-linter.yml@master

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write **/*.{md} # Prettify all markdown files
+          prettier_options: . --write # Prettify all files in the repository.
   lint:
     if: ${{ always() }} # This job will always run after the prettier job, regardless of the outcome. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs
     needs: prettier


### PR DESCRIPTION
At the moment, the release please action creates and manages the change log but it is not formatted correctly. This adds a step to the current pipeline to run the linter for the change log (markdown) if the pull request is the one created and controlled by the release please action. This step is attached to the super linter workflow but will execute before the super linter.