### PR TITLE
fix: Add major version to the module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/andrew-field/maths
+module github.com/andrew-field/maths/v2
 
 go 1.24.0


### PR DESCRIPTION
This is necessary for versions above v2
https://go.dev/ref/mod#major-version-suffixes