### PR TITLE
feat: Update go version to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/andrew-field/maths/v2
 
-go 1.24.1
+go 1.24.2


### PR DESCRIPTION
- Auto-generated by [bump-go-mod-version][1] Github action.

[1]: https://github.com/andrew-field/reusable-workflows/actions/workflows/bump-go-mod-version.yml